### PR TITLE
Avoid unnecessary altitude calculations to improve performance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,14 +601,16 @@ where
     /// # let mut sensor = Bmp390::try_new(i2c, bmp390::Address::Up, delay, &config).await?;
     /// let (temperature, pressure) = sensor.temperature_pressure().await?;
     /// defmt::info!(
-    ///     "Temperature: {} °C, Pressure: {} hPa", 
-    ///     temperature.get::<degree_celsius>(), 
+    ///     "Temperature: {} °C, Pressure: {} hPa",
+    ///     temperature.get::<degree_celsius>(),
     ///     pressure.get::<hectopascal>()
     /// );
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn temperature_pressure(&mut self) -> Result<(ThermodynamicTemperature, Pressure), Error<E>> {
+    pub async fn temperature_pressure(
+        &mut self,
+    ) -> Result<(ThermodynamicTemperature, Pressure), Error<E>> {
         // Burst read: only address DATA_0 (pressure XLSB) and BMP390 auto-increments through DATA_5 (temperature MSB)
         let write = &[Register::DATA_0.into()];
         let mut read = [0; 6];
@@ -626,7 +628,7 @@ where
         let pressure = u32::from(read[0]) | u32::from(read[1]) << 8 | u32::from(read[2]) << 16;
         let pressure = self.coefficients.compensate_pressure(temperature, pressure);
 
-        Ok((temperature,pressure))
+        Ok((temperature, pressure))
     }
 
     /// Reads the pressure from the barometer as a [`Pressure`].
@@ -654,7 +656,7 @@ where
 
     /// Measures the temperature and pressure from the barometer.
     /// Altitude is then calculated using the [NOAA formula](https://www.weather.gov/media/epz/wxcalc/pressureAltitude.pdf).
-    /// 
+    ///
     /// This altitude calculation can be expensive on devices without floating point hardware. In this case, consider
     /// calling [`temperature_pressure()`] instead and using an approximation or lookup table.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -884,7 +884,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_measure_reads_temperature_and_pressure() {
+    async fn test_reads_temperature_pressure() {
         let addr = Address::Up;
         let expectations = [I2cTransaction::write_read(
             addr.into(),
@@ -895,9 +895,9 @@ mod tests {
         let mut i2c = Mock::new(&expectations);
         let mut bmp390 =
             Bmp390::new_with_coefficients(i2c.clone(), addr, CalibrationCoefficients::default());
-        let measurement = bmp390.measure().await.unwrap();
-        assert_eq!(measurement.temperature, expected_temperature());
-        assert_eq!(measurement.pressure, expected_pressure());
+        let measurement = bmp390.temperature_pressure().await.unwrap();
+        assert_eq!(measurement.0, expected_temperature());
+        assert_eq!(measurement.1, expected_pressure());
         i2c.done();
     }
 
@@ -917,6 +917,25 @@ mod tests {
             Bmp390::new_with_coefficients(i2c.clone(), addr, CalibrationCoefficients::default());
         let altitude = bmp390.altitude().await.unwrap();
         assert_eq!(altitude, expected_altitude());
+        i2c.done();
+    }
+
+    #[tokio::test]
+    async fn test_measure_reads_temperature_pressure_altitude() {
+        let addr = Address::Up;
+        let expectations = [I2cTransaction::write_read(
+            addr.into(),
+            vec![Register::DATA_0.into()],
+            PRESSURE_TEMPERATURE_BYTES.to_vec(),
+        )];
+
+        let mut i2c = Mock::new(&expectations);
+        let mut bmp390 =
+            Bmp390::new_with_coefficients(i2c.clone(), addr, CalibrationCoefficients::default());
+        let measurement = bmp390.measure().await.unwrap();
+        assert_eq!(measurement.temperature, expected_temperature());
+        assert_eq!(measurement.pressure, expected_pressure());
+        assert_eq!(measurement.altitude, expected_altitude());
         i2c.done();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -587,6 +587,47 @@ where
         Ok(temperature)
     }
 
+    /// Measures the temperature and pressure from the barometer.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use embedded_hal_mock::eh1::{delay::NoopDelay, i2c::Mock};
+    /// # use bmp390::Bmp390;
+    /// # async fn run() -> Result<(), bmp390::Error<embedded_hal_async::i2c::ErrorKind>> {
+    /// # let config = bmp390::Configuration::default();
+    /// # let i2c = embedded_hal_mock::eh1::i2c::Mock::new(&[]);
+    /// # let delay = embedded_hal_mock::eh1::delay::NoopDelay::new();
+    /// # let mut sensor = Bmp390::try_new(i2c, bmp390::Address::Up, delay, &config).await?;
+    /// let measurement = sensor.temperature_pressure().await?;
+    /// defmt::info!(
+    ///     "Temperature: {} °C, Pressure: {} hPa", 
+    ///     temperature.get::<degree_celsius>(), 
+    ///     pressure.get::<hectopascal>()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn temperature_pressure(&mut self) -> Result<(ThermodynamicTemperature, Pressure), Error<E>> {
+        // Burst read: only address DATA_0 (pressure XLSB) and BMP390 auto-increments through DATA_5 (temperature MSB)
+        let write = &[Register::DATA_0.into()];
+        let mut read = [0; 6];
+        self.i2c
+            .write_read(self.address.into(), write, &mut read)
+            .await
+            .map_err(Error::I2c)?;
+
+        trace!("DATA = {=[u8]:#04x}", read);
+
+        // pressure is 0:2 (XLSB, LSB, MSB), temperature is 3:5 (XLSB, LSB, MSB)
+        let temperature = u32::from(read[3]) | u32::from(read[4]) << 8 | u32::from(read[5]) << 16;
+        let temperature = self.coefficients.compensate_temperature(temperature);
+
+        let pressure = u32::from(read[0]) | u32::from(read[1]) << 8 | u32::from(read[2]) << 16;
+        let pressure = self.coefficients.compensate_pressure(temperature, pressure);
+
+        Ok((temperature,pressure))
+    }
+
     /// Reads the pressure from the barometer as a [`Pressure`].
     ///
     /// # Example
@@ -605,12 +646,16 @@ where
     /// # }
     /// ```
     pub async fn pressure(&mut self) -> Result<Pressure, Error<E>> {
-        // pressure requires temperature to compensate, so just measure both
-        let measurement = self.measure().await?;
-        Ok(measurement.pressure)
+        // pressure requires temperature to compensate, so we have to measure both
+        let (_, pressure) = self.temperature_pressure().await?;
+        Ok(pressure)
     }
 
-    /// Measures the pressure and temperature from the barometer.
+    /// Measures the temperature and pressure from the barometer.
+    /// Altitude is then calculated using the [NOAA formula](https://www.weather.gov/media/epz/wxcalc/pressureAltitude.pdf).
+    /// 
+    /// This altitude calculation can be expensive on devices without floating point hardware. In this case, consider
+    /// calling [`temperature_pressure()`] instead and using an approximation or lookup table.
     ///
     /// # Example
     /// ```no_run
@@ -627,22 +672,7 @@ where
     /// # }
     /// ```
     pub async fn measure(&mut self) -> Result<Measurement, Error<E>> {
-        // Burst read: only address DATA_0 (pressure XLSB) and BMP390 auto-increments through DATA_5 (temperature MSB)
-        let write = &[Register::DATA_0.into()];
-        let mut read = [0; 6];
-        self.i2c
-            .write_read(self.address.into(), write, &mut read)
-            .await
-            .map_err(Error::I2c)?;
-
-        trace!("DATA = {=[u8]:#04x}", read);
-
-        // pressure is 0:2 (XLSB, LSB, MSB), temperature is 3:5 (XLSB, LSB, MSB)
-        let temperature = u32::from(read[3]) | u32::from(read[4]) << 8 | u32::from(read[5]) << 16;
-        let temperature = self.coefficients.compensate_temperature(temperature);
-
-        let pressure = u32::from(read[0]) | u32::from(read[1]) << 8 | u32::from(read[2]) << 16;
-        let pressure = self.coefficients.compensate_pressure(temperature, pressure);
+        let (temperature, pressure) = self.temperature_pressure().await?;
 
         Ok(Measurement {
             temperature,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -593,12 +593,13 @@ where
     /// ```no_run
     /// # use embedded_hal_mock::eh1::{delay::NoopDelay, i2c::Mock};
     /// # use bmp390::Bmp390;
+    /// use uom::si::{pressure::hectopascal, thermodynamic_temperature::degree_celsius};
     /// # async fn run() -> Result<(), bmp390::Error<embedded_hal_async::i2c::ErrorKind>> {
     /// # let config = bmp390::Configuration::default();
     /// # let i2c = embedded_hal_mock::eh1::i2c::Mock::new(&[]);
     /// # let delay = embedded_hal_mock::eh1::delay::NoopDelay::new();
     /// # let mut sensor = Bmp390::try_new(i2c, bmp390::Address::Up, delay, &config).await?;
-    /// let measurement = sensor.temperature_pressure().await?;
+    /// let (temperature, pressure) = sensor.temperature_pressure().await?;
     /// defmt::info!(
     ///     "Temperature: {} °C, Pressure: {} hPa", 
     ///     temperature.get::<degree_celsius>(), 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -225,13 +225,13 @@ where
     /// ```no_run
     /// # use embedded_hal_mock::eh1::{delay::NoopDelay, i2c::Mock};
     /// # use bmp390::sync::Bmp390;
-    /// use uom::si::pressure::hectopascal;
+    /// use uom::si::{pressure::hectopascal, thermodynamic_temperature::degree_celsius};
     /// # fn run() -> Result<(), bmp390::Error<embedded_hal::i2c::ErrorKind>> {
     /// # let config = bmp390::Configuration::default();
     /// # let i2c = embedded_hal_mock::eh1::i2c::Mock::new(&[]);
     /// # let delay = embedded_hal_mock::eh1::delay::NoopDelay::new();
     /// # let mut sensor = Bmp390::try_new(i2c, bmp390::Address::Up, delay, &config)?;
-    /// let pressure = sensor.temperature_pressure()?;
+    /// let (temperature, pressure) = sensor.temperature_pressure()?;
     /// defmt::info!(
     ///     "Temperature: {} °C, Pressure: {} hPa", 
     ///     temperature.get::<degree_celsius>(), 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -233,14 +233,16 @@ where
     /// # let mut sensor = Bmp390::try_new(i2c, bmp390::Address::Up, delay, &config)?;
     /// let (temperature, pressure) = sensor.temperature_pressure()?;
     /// defmt::info!(
-    ///     "Temperature: {} °C, Pressure: {} hPa", 
-    ///     temperature.get::<degree_celsius>(), 
+    ///     "Temperature: {} °C, Pressure: {} hPa",
+    ///     temperature.get::<degree_celsius>(),
     ///     pressure.get::<hectopascal>()
     /// );
     /// # Ok(())
     /// # }
     /// ```
-    pub fn temperature_pressure(&mut self) -> Result<(ThermodynamicTemperature, Pressure), Error<E>> {
+    pub fn temperature_pressure(
+        &mut self,
+    ) -> Result<(ThermodynamicTemperature, Pressure), Error<E>> {
         // pressure requires temperature to compensate, so just measure both
         // pressure requires temperature to compensate, so just measure both
         let write = &[Register::DATA_0.into()];
@@ -252,11 +254,14 @@ where
         trace!("DATA = {=[u8]:#04x}", read);
 
         // pressure is 0:2 (XLSB, LSB, MSB), temperature is 3:5 (XLSB, LSB, MSB)
-        let temperature_raw = u32::from(read[3]) | u32::from(read[4]) << 8 | u32::from(read[5]) << 16;
-        let pressure_raw    = u32::from(read[0]) | u32::from(read[1]) << 8 | u32::from(read[2]) << 16;
-        
+        let temperature_raw =
+            u32::from(read[3]) | u32::from(read[4]) << 8 | u32::from(read[5]) << 16;
+        let pressure_raw = u32::from(read[0]) | u32::from(read[1]) << 8 | u32::from(read[2]) << 16;
+
         let temperature = self.coefficients.compensate_temperature(temperature_raw);
-        let pressure = self.coefficients.compensate_pressure(temperature, pressure_raw);
+        let pressure = self
+            .coefficients
+            .compensate_pressure(temperature, pressure_raw);
 
         Ok((temperature, pressure))
     }
@@ -285,7 +290,7 @@ where
 
     /// Measures the temperature and pressure from the barometer.
     /// Altitude is then calculated using the [NOAA formula](https://www.weather.gov/media/epz/wxcalc/pressureAltitude.pdf).
-    /// 
+    ///
     /// This altitude calculation can be expensive on devices without floating point hardware. In this case, consider
     /// calling [`temperature_pressure()`] instead and using an approximation or lookup table.
     ///

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -498,7 +498,7 @@ mod tests {
     }
 
     #[test]
-    fn test_measure_reads_temperature_and_pressure() {
+    fn test_reads_temperature_pressure() {
         let addr = Address::Up;
         let expectations = [I2cTransaction::write_read(
             addr.into(),
@@ -509,9 +509,9 @@ mod tests {
         let mut i2c = Mock::new(&expectations);
         let mut bmp390 =
             Bmp390::new_with_coefficients(i2c.clone(), addr, CalibrationCoefficients::default());
-        let measurement = bmp390.measure().unwrap();
-        assert_eq!(measurement.temperature, expected_temperature());
-        assert_eq!(measurement.pressure, expected_pressure());
+        let measurement = bmp390.temperature_pressure().unwrap();
+        assert_eq!(measurement.0, expected_temperature());
+        assert_eq!(measurement.1, expected_pressure());
         i2c.done();
     }
 
@@ -531,6 +531,25 @@ mod tests {
             Bmp390::new_with_coefficients(i2c.clone(), addr, CalibrationCoefficients::default());
         let altitude = bmp390.altitude().unwrap();
         assert_eq!(altitude, expected_altitude());
+        i2c.done();
+    }
+
+    #[test]
+    fn test_measure_reads_temperature_pressure_altitude() {
+        let addr = Address::Up;
+        let expectations = [I2cTransaction::write_read(
+            addr.into(),
+            vec![Register::DATA_0.into()],
+            PRESSURE_TEMPERATURE_BYTES.to_vec(),
+        )];
+
+        let mut i2c = Mock::new(&expectations);
+        let mut bmp390 =
+            Bmp390::new_with_coefficients(i2c.clone(), addr, CalibrationCoefficients::default());
+        let measurement = bmp390.measure().unwrap();
+        assert_eq!(measurement.temperature, expected_temperature());
+        assert_eq!(measurement.pressure, expected_pressure());
+        assert_eq!(measurement.altitude, expected_altitude());
         i2c.done();
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -220,6 +220,47 @@ where
         Ok(temperature)
     }
 
+    /// Reads temperature and pressure from the barometer.
+    /// # Example
+    /// ```no_run
+    /// # use embedded_hal_mock::eh1::{delay::NoopDelay, i2c::Mock};
+    /// # use bmp390::sync::Bmp390;
+    /// use uom::si::pressure::hectopascal;
+    /// # fn run() -> Result<(), bmp390::Error<embedded_hal::i2c::ErrorKind>> {
+    /// # let config = bmp390::Configuration::default();
+    /// # let i2c = embedded_hal_mock::eh1::i2c::Mock::new(&[]);
+    /// # let delay = embedded_hal_mock::eh1::delay::NoopDelay::new();
+    /// # let mut sensor = Bmp390::try_new(i2c, bmp390::Address::Up, delay, &config)?;
+    /// let pressure = sensor.temperature_pressure()?;
+    /// defmt::info!(
+    ///     "Temperature: {} °C, Pressure: {} hPa", 
+    ///     temperature.get::<degree_celsius>(), 
+    ///     pressure.get::<hectopascal>()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn temperature_pressure(&mut self) -> Result<(ThermodynamicTemperature, Pressure), Error<E>> {
+        // pressure requires temperature to compensate, so just measure both
+        // pressure requires temperature to compensate, so just measure both
+        let write = &[Register::DATA_0.into()];
+        let mut read = [0; 6];
+        self.i2c
+            .write_read(self.address.into(), write, &mut read)
+            .map_err(Error::I2c)?;
+
+        trace!("DATA = {=[u8]:#04x}", read);
+
+        // pressure is 0:2 (XLSB, LSB, MSB), temperature is 3:5 (XLSB, LSB, MSB)
+        let temperature_raw = u32::from(read[3]) | u32::from(read[4]) << 8 | u32::from(read[5]) << 16;
+        let pressure_raw    = u32::from(read[0]) | u32::from(read[1]) << 8 | u32::from(read[2]) << 16;
+        
+        let temperature = self.coefficients.compensate_temperature(temperature_raw);
+        let pressure = self.coefficients.compensate_pressure(temperature, pressure_raw);
+
+        Ok((temperature, pressure))
+    }
+
     /// Reads the pressure from the barometer as a [`Pressure`].
     ///
     /// # Example
@@ -238,12 +279,15 @@ where
     /// # }
     /// ```
     pub fn pressure(&mut self) -> Result<Pressure, Error<E>> {
-        // pressure requires temperature to compensate, so just measure both
-        let measurement = self.measure()?;
-        Ok(measurement.pressure)
+        // pressure requires temperature to compensate, so we have to measure both
+        self.temperature_pressure().map(|(_, pressure)| pressure)
     }
 
-    /// Measures the pressure and temperature from the barometer.
+    /// Measures the temperature and pressure from the barometer.
+    /// Altitude is then calculated using the [NOAA formula](https://www.weather.gov/media/epz/wxcalc/pressureAltitude.pdf).
+    /// 
+    /// This altitude calculation can be expensive on devices without floating point hardware. In this case, consider
+    /// calling [`temperature_pressure()`] instead and using an approximation or lookup table.
     ///
     /// # Example
     /// ```no_run
@@ -260,21 +304,7 @@ where
     /// # }
     /// ```
     pub fn measure(&mut self) -> Result<Measurement, Error<E>> {
-        // Burst read: only address DATA_0 (pressure XLSB) and BMP390 auto-increments through DATA_5 (temperature MSB)
-        let write = &[Register::DATA_0.into()];
-        let mut read = [0; 6];
-        self.i2c
-            .write_read(self.address.into(), write, &mut read)
-            .map_err(Error::I2c)?;
-
-        trace!("DATA = {=[u8]:#04x}", read);
-
-        // pressure is 0:2 (XLSB, LSB, MSB), temperature is 3:5 (XLSB, LSB, MSB)
-        let temperature = u32::from(read[3]) | u32::from(read[4]) << 8 | u32::from(read[5]) << 16;
-        let temperature = self.coefficients.compensate_temperature(temperature);
-
-        let pressure = u32::from(read[0]) | u32::from(read[1]) << 8 | u32::from(read[2]) << 16;
-        let pressure = self.coefficients.compensate_pressure(temperature, pressure);
+        let (temperature, pressure) = self.temperature_pressure()?;
 
         Ok(Measurement {
             temperature,


### PR DESCRIPTION
Hi, 

I'm using this library on an embedded device with no floating point hardware (MSP430) and after some profiling I noticed that almost 66% of the runtime of `bmp390.pressure()` was coming from the (unused) altitude calculation that occurs as part of the internal call to `self.measure()` (17ms total, altitude took 11ms). 

To remedy this I moved the body of `measure()` into a new public method `temperature_pressure()` that returns just the temperature and pressure, and updated the other methods to call this instead to avoid any altitude calculations that aren't required. 
The new method is public to allow the user to calculate altitude themselves, should they wish to use an approximation or lookup table for performance reasons.

Any comments or edits welcome.
